### PR TITLE
Fix doc title overflow under browser UI

### DIFF
--- a/static/_sass/custom/custom.scss
+++ b/static/_sass/custom/custom.scss
@@ -9,13 +9,6 @@
     }
 }
 
-/* Remove that for solution 1: bigger container, same text size */
-@media (min-width: 31.25rem) {
-    .site-title {
-        font-size: 22px !important;
-    }
-}
-
 @media (min-width: 50rem) {
     .site-nav {
         padding-top: 1rem;

--- a/static/_sass/custom/custom.scss
+++ b/static/_sass/custom/custom.scss
@@ -1,3 +1,23 @@
 .hidden {
     display: none;
-  }
+}
+
+/* Remove that for solution 2: same container, smaller text size */
+@media (min-width: 50rem) {
+    .site-header {
+        min-height: 100px;
+    }
+}
+
+/* Remove that for solution 1: bigger container, same text size */
+@media (min-width: 31.25rem) {
+    .site-title {
+        font-size: 22px !important;
+    }
+}
+
+@media (min-width: 50rem) {
+    .site-nav {
+        padding-top: 1rem;
+    }
+}


### PR DESCRIPTION
(the top red bar is my browser UI)

**BEFORE**
![image](https://user-images.githubusercontent.com/14821482/229178020-3a654113-1ba4-4beb-be23-f0e203ef4141.png)

**AFTER** solution 1: bigger container, same text size
![image](https://user-images.githubusercontent.com/14821482/229179446-77cff379-8c65-41a8-add8-5766694e3926.png)
The line under the title isn't "continuing" with the one under the search field

**AFTER** solution 2: same container, smaller text size
![image](https://user-images.githubusercontent.com/14821482/229179693-fc136e2e-44db-449f-a23e-61b557207585.png)
There is no line section

I started with solution 1, but I may prefer 2 finally.
As you wish !

Fixes #44