### PR TITLE
Entity naming and improvements

### DIFF
--- a/everything-presence-one.yaml
+++ b/everything-presence-one.yaml
@@ -105,7 +105,6 @@ binary_sensor:
     name: mmWave
     id: mmwave
     device_class: occupancy
-    entity_category: diagnostic
     pin:
       number: GPIO15
       mode: INPUT_PULLDOWN
@@ -116,7 +115,6 @@ binary_sensor:
     name: PIR
     id: pir_motion_sensor
     device_class: motion
-    entity_category: diagnostic
     filters:
       - delayed_off: ${pir_delay_off}
   - platform: template

--- a/everything-presence-one.yaml
+++ b/everything-presence-one.yaml
@@ -1,6 +1,5 @@
 substitutions:
   name: "everything-presence-one"
-  room: ""
   friendly_name: "Everything Presence One"
   project_name: "Everything Smart Technology.Everything Presence One"
   project_version: "1.1.3"
@@ -16,11 +15,12 @@ substitutions:
   uart_presence_output_disabled: "true"
 
 esphome:
-  name: "${name}"
+  name: ${name}
+  friendly_name: ${friendly_name}
   name_add_mac_suffix: true
   project:
-    name: "${project_name}"
-    version: "${project_version}"
+    name: ${project_name}
+    version: ${project_version}
 
 esp32:
   board: esp32dev
@@ -41,16 +41,42 @@ improv_serial:
 
 esp32_improv:
   authorizer: none
-  
+
 dashboard_import:
   package_import_url: github://everythingsmarthome/presence-one/everything-presence-one.yaml@main
   import_full_config: false
 
 light:
   - platform: status_led
-    name: "ESP32 Status LED"
+    name: ESP32 status LED
     pin: GPIO32
     entity_category: config
+    disabled_by_default: True
+  - platform: binary
+    name: mmWave LED
+    restore_mode: RESTORE_DEFAULT_OFF
+    output: mmwave_led_output
+    entity_category: config
+    disabled_by_default: True
+
+output:
+  - platform: template
+    id: mmwave_led_output
+    type: binary
+    write_action:
+      - switch.turn_off: mmwave_sensor
+      - delay: 1s
+      - if:
+          condition:
+            lambda: !lambda return state;
+          then:
+            - uart.write: "setLedMode 1 0"
+          else:
+            - uart.write: "setLedMode 1 1"
+      - delay: 1s
+      - uart.write: "saveConfig"
+      - delay: 3s
+      - switch.turn_on: mmwave_sensor
 
 i2c:
   sda: 26
@@ -60,25 +86,26 @@ i2c:
 sensor:
   - platform: shtcx
     temperature:
-      name: "${room} Temperature"
+      name: Temperature
       filters:
         offset: ${temperature_offset}
     humidity:
-      name: "${room} Humidity"
+      name: Humidity
       filters:
         offset: ${humidity_offset}
     address: 0x70
     update_interval: ${temperature_update_interval}
   - platform: bh1750
-    name: "${room} Illuminance"
+    name: Illuminance
     address: 0x23
     update_interval: ${illuminance_update_interval}
 
 binary_sensor:
   - platform: gpio
-    name: ${room} mmWave
+    name: mmWave
     id: mmwave
     device_class: occupancy
+    entity_category: diagnostic
     pin:
       number: GPIO15
       mode: INPUT_PULLDOWN
@@ -86,13 +113,14 @@ binary_sensor:
     pin:
       number: 33
       mode: INPUT_PULLDOWN
-    name: ${room} PIR
+    name: PIR
     id: pir_motion_sensor
     device_class: motion
+    entity_category: diagnostic
     filters:
       - delayed_off: ${pir_delay_off}
   - platform: template
-    name: ${room} Occupancy
+    name: Occupancy
     id: occupancy
     device_class: occupancy
     filters:
@@ -122,8 +150,9 @@ uart:
 
 switch:
   - platform: template
-    name: "mmWave Sensor"
-    id: "mmwave_sensor"
+    name: mmWave sensor
+    id: mmwave_sensor
+    disabled_by_default: True
     entity_category: config
     optimistic: true
     restore_state: true
@@ -135,31 +164,8 @@ switch:
       - delay: 1s
 
   - platform: template
-    name: "mmWave LED"
-    id: "mmwave_led"
-    entity_category: config
-    optimistic: true
-    restore_state: true
-    turn_on_action:
-      - switch.turn_off: mmwave_sensor
-      - delay: 1s
-      - uart.write: "setLedMode 1 0"
-      - delay: 1s
-      - uart.write: "saveConfig"
-      - delay: 3s
-      - switch.turn_on: mmwave_sensor
-    turn_off_action:
-      - switch.turn_off: mmwave_sensor
-      - delay: 1s
-      - uart.write: "setLedMode 1 1"
-      - delay: 1s
-      - uart.write: "saveConfig"
-      - delay: 3s
-      - switch.turn_on: mmwave_sensor
-
-  - platform: template
-    name: "uart_presence_output"
-    id: "uart_presence_output"
+    name: UART presence output
+    id: uart_presence_output
     entity_category: config
     internal: ${uart_presence_output_disabled}
     optimistic: true
@@ -182,8 +188,8 @@ switch:
       - switch.turn_on: mmwave_sensor
 
   - platform: template
-    name: "uart_target_output"
-    id: "uart_target_output"
+    name: UART target output
+    id: uart_target_output
     entity_category: config
     internal: ${uart_target_output_disabled}
     optimistic: true
@@ -208,8 +214,9 @@ switch:
 
 number:
   - platform: template
-    name: mmWave Distance
     id: mmwave_distance
+    name: mmWave distance
+    icon: mdi:arrow-left-right
     entity_category: config
     min_value: 0
     max_value: 800
@@ -231,9 +238,10 @@ number:
       - switch.turn_on: mmwave_sensor
 
   - platform: template
-    name: mmWave Off Latency
-    id: mmwave_off_latency
+    name: mmWave off latency
+    icon: mdi:clock-end
     entity_category: config
+    id: mmwave_off_latency
     min_value: 1
     max_value: 60
     initial_value: 15
@@ -254,7 +262,8 @@ number:
       - switch.turn_on: mmwave_sensor
 
   - platform: template
-    name: mmWave On Latency
+    name: mmWave on latency
+    icon: mdi:clock-start
     id: mmwave_on_latency
     entity_category: config
     min_value: 0
@@ -277,7 +286,8 @@ number:
       - switch.turn_on: mmwave_sensor
 
   - platform: template
-    name: mmWave Sensitivity
+    name: mmWave sensitivity
+    icon: mdi:target-variant
     id: mmwave_sensitivity
     entity_category: config
     min_value: 0
@@ -299,30 +309,33 @@ number:
 
 button:
   - platform: restart
-    name: Restart_internal
     id: restart_internal
-    entity_category: config 
+    entity_category: config
     internal: true
   - platform: template
-    name: "Restart mmWave Sensor"
-    id: "restart_mmwave"
+    name: Restart mmWave sensor
+    id: restart_mmwave
     entity_category: config
     internal: true
     on_press:
       - uart.write: "resetSystem"
   - platform: template
-    name: Restart $name
+    name: Restart
+    icon: mdi:restart
     entity_category: config
+    disabled_by_default: True
     on_press:
       - button.press: restart_mmwave
       - button.press: restart_internal
   - platform: safe_mode
     internal: false
-    name: $name Safe Mode
+    name: Safe mode
     entity_category: config
+    disabled_by_default: True
   - platform: template
-    name: "Factory Reset mmWave"
-    id: "factory_reset_mmwave"
+    name: Factory reset mmWave
+    icon: mdi:cog-counterclockwise
+    id: factory_reset_mmwave
     internal: ${factory_reset_disabled}
     entity_category: config
     on_press:

--- a/everything-presence-one.yaml
+++ b/everything-presence-one.yaml
@@ -2,7 +2,7 @@ substitutions:
   name: "everything-presence-one"
   friendly_name: "Everything Presence One"
   project_name: "Everything Smart Technology.Everything Presence One"
-  project_version: "1.1.3"
+  project_version: "1.1.4"
   temperature_offset: "-3"
   humidity_offset: "5"
   temperature_update_interval: "60s"


### PR DESCRIPTION
I did some improvements to have better default and naming in Home Assistant.

## What's changed
- Use entity naming (by adding friendly name : https://esphome.io/changelog/2023.2.0.html#friendly-name)
  - room is gone because it's not needed aymore with this. By renaming the device in HA, all entity ids will be renamed.
  - entity ID will have this format : `{device}_{mac}_{entity}` (example : `sensor.everything_presence_one_d723f3_occupancy`)
- Hide some entities by default 
  - safe mode
  - restart
  - status led
  - mmwave led
  - mmwave switch
- ~~Put some entities in diagnostic (they will not appear in the default dashboard)~~
  - ~~mmwave~~
  - ~~PIR~~
- Convert mmwave from switch to light
- Add icons 🧑‍🎨

## How it looks by default in Home Assistant

![CleanShot 2023-06-30 at 17 38 16@2x](https://github.com/EverythingSmartHome/everything-presence-one/assets/5878303/e46fb089-55c7-49d5-a54e-65e91581dc18)

Feel free to add some feedback if there is something you like/dislike or something I can improve 🙂


