### PR TITLE
Add Binary Sensor Platform Status

### DIFF
--- a/everything-presence-one.yaml
+++ b/everything-presence-one.yaml
@@ -101,6 +101,8 @@ sensor:
     update_interval: ${illuminance_update_interval}
 
 binary_sensor:
+  - platform: status
+    name: Status
   - platform: gpio
     name: mmWave
     id: mmwave


### PR DESCRIPTION
Add the binary platform status for viewing device connectivity status in Home Assistant.  This allows users to create an automation in Home Assistant to alert them if the device goes offline.

[https://esphome.io/components/binary_sensor/status.html](https://esphome.io/components/binary_sensor/status.html)