### PR TITLE
Add multiple target tracking

### DIFF
--- a/SEN0395_distance.h
+++ b/SEN0395_distance.h
@@ -5,102 +5,98 @@ class Sen0395Distance : public Component, public UARTDevice {
 public:
   Sen0395Distance(UARTComponent *parent) : UARTDevice(parent) {}
 
-float t_snr[10] = {0,0,0,0,0,0,0,0,0,0};
-float t_distance[10] = {0,0,0,0,0,0,0,0,0,0};
+  float t_snr[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  float t_distance[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  bool t_active[10] = {false, false, false, false, false, false, false, false, false, false};
 
-void setup() override {
+  void setup() override {
     // nothing to do here
-}
-
-int readline(int readch, char *buffer, int len)
-{
-  static int pos = 0;
-  int rpos;
-
-  if (readch > 0) {
-    switch (readch) {
-      case '\n': // Ignore new-lines
-        break;
-      case '\r': // Return on CR
-        rpos = pos;
-        pos = 0;  // Reset position index ready for next time
-        return rpos;
-      default:
-        if (pos < len-1) {
-          buffer[pos++] = readch;
-          buffer[pos] = 0;
-        }
-    }
   }
-  // No end of line has been found, so return -1.
-  return -1;
-}
 
+  int readline(int readch, char *buffer, int len) {
+    static int pos = 0;
+    int rpos;
 
-std::string getline;
+    if (readch > 0) {
+      switch (readch) {
+        case '\n': // Ignore new-lines
+          break;
+        case '\r': // Return on CR
+          rpos = pos;
+          pos = 0; // Reset position index ready for next time
+          return rpos;
+        default:
+          if (pos < len - 1) {
+            buffer[pos++] = readch;
+            buffer[pos] = 0;
+          }
+      }
+    }
+    // No end of line has been found, so return -1.
+    return -1;
+  }
 
-void loop() override {
-const int max_line_length = 40;
+  void loop() override {
+    const int max_line_length = 40;
     static char buffer[max_line_length];
 
     while (available()) {
-      if(readline(read(), buffer, max_line_length) >= 4) {
+      if (readline(read(), buffer, max_line_length) >= 4) {
         std::string line = buffer;
-
 
         if (line.substr(0, 6) == "$JYRPO") {
           std::string vline = line.substr(6);
-          std::vector<std::string> v;    
-          for(int i = 0; i < vline.length(); i++) {
-              if(vline[i] == ',') {
-                  v.push_back("");
-              } else {
-                  v.back() += vline[i];
-              }
+          std::vector<std::string> v;
+          for (int i = 0; i < vline.length(); i++) {
+            if (vline[i] == ',') {
+              v.push_back("");
+            } else {
+              v.back() += vline[i];
+            }
           }
           int target_count = parse_number<int>(v[0]).value();
           int target_index = parse_number<int>(v[1]).value();
           float target_distance = parse_number<float>(v[2]).value();
           float target_snr = parse_number<float>(v[4]).value();
 
-         // ESP_LOGD("custom","target_count: %d", target_count);
-         // ESP_LOGD("custom","target_index: %d", target_index);
-         // ESP_LOGD("custom","target_snr: %f", target_snr);
-         // ESP_LOGD("custom","target_distance: %f", target_distance);
-
+          // Update the SNR, distance, and active status for the current target index
           t_snr[target_index] = target_snr;
           t_distance[target_index] = target_distance;
+          t_active[target_index] = true;
 
-          if(target_count == target_index){
-            float max_snr = 0;
-            float max_distance = 0;
-            int max_index = 0;
-            for(int i =1; i<= target_count;i++){
-              if(t_snr[i] > max_snr){
-                max_snr = t_snr[i];
-                max_distance = t_distance[i];
-                max_index = i;
+          if (target_count == target_index) {
+            // Publish the data for each target without sorting
+            for (int i = 1; i <= target_count; i++) {
+              auto get_sensors = App.get_sensors();
+              for (int j = 0; j < get_sensors.size(); j++) {
+                std::string name = get_sensors[j]->get_name();
+                if (name == "Target " + std::to_string(i) + " Distance") {
+                  get_sensors[j]->publish_state(t_distance[i]);
+                } else if (name == "Target " + std::to_string(i) + " SNR") {
+                  get_sensors[j]->publish_state(t_snr[i]);
+                }
               }
             }
 
-            auto get_sensors = App.get_sensors();
-            for(int i = 0; i < get_sensors.size(); i++) {
-              std::string name = get_sensors[i]->get_name();
-                if(name == "Target Distance m") {
-                  get_sensors[i]->publish_state(max_distance);
-                } 
+            // Publish the state of the binary sensor for each target
+            for (int i = 1; i <= 10; i++) {
+              auto get_binary_sensors = App.get_binary_sensors();
+              for (int j = 0; j < get_binary_sensors.size(); j++) {
+                std::string name = get_binary_sensors[j]->get_name();
+                if (name == "Target " + std::to_string(i) + " Active") {
+                  get_binary_sensors[j]->publish_state(t_active[i]);
+                }
+              }
             }
-            
-            ESP_LOGD("custom","%f, %f, %f, %f, %f, %f, %f, %f, %f",t_snr[1],t_snr[2],t_snr[3],t_snr[4],t_snr[5],t_snr[6],t_snr[7],t_snr[8],t_snr[9]);
-            ESP_LOGD("custom","%f, %f, %f, %f, %f, %f, %f, %f, %f",t_distance[1],t_distance[2],t_distance[3],t_distance[4],t_distance[5],t_distance[6],t_distance[7],t_distance[8],t_distance[9]);            
-            ESP_LOGD("custom","Distance: %f",max_distance);
-            ESP_LOGD("custom","SNR: %f",t_snr[max_index]);
-            ESP_LOGD("custom","Distance: %f",max_distance);
-            ESP_LOGD("custom","idx: %d",max_index);
+
+            for (int i = target_count + 1; i <= 9; i++) {
+              t_active[i] = false;
+            }
+
+            //ESP_LOGD("custom", "Target %d Distance: %f, SNR: %f", i, t_distance[i], t_snr[i]);
           }
         }
-        getline = buffer; 
+      }
     }
   }
-}
 };

--- a/everything-presence-one-beta.yaml
+++ b/everything-presence-one-beta.yaml
@@ -2,7 +2,7 @@ substitutions:
   name: "everything-presence-beta"
   friendly_name: "Everything Presence One"
   project_name: "Everything Smart Technology.Everything Presence One"
-  project_version: "1.2.2b"
+  project_version: "1.2.3b"
   temperature_offset: "-3"
   humidity_offset: "5"
   temperature_update_interval: "60s"
@@ -105,9 +105,37 @@ sensor:
     filters:
       - lambda: "return x + id(illuminance_offset_ui).state;"
   - platform: template
-    name: Target Distance m
-    id: target_distance_m # do not change
-    accuracy_decimals: 5
+    name: Target 1 Distance # Don't change
+    id: target_distance_1_m
+    accuracy_decimals: 2
+    disabled_by_default: false
+  - platform: template
+    name: Target 2 Distance # Don't change
+    id: target_distance_2_m
+    accuracy_decimals: 2
+    disabled_by_default: True
+  - platform: template
+    name: Target 3 Distance # Don't change
+    id: target_distance_3_m
+    accuracy_decimals: 2
+    disabled_by_default: True
+  - platform: template
+    name: Target 4 Distance # Don't change
+    id: target_distance_4_m
+    accuracy_decimals: 2
+    disabled_by_default: True
+  - platform: template
+    name: "Target 1 SNR" # Don't change
+    disabled_by_default: True
+  - platform: template
+    name: "Target 2 SNR" # Don't change
+    disabled_by_default: True
+  - platform: template
+    name: "Target 3 SNR" # Don't change
+    disabled_by_default: True
+  - platform: template
+    name: "Target 4 SNR" # Don't change
+    disabled_by_default: True
 
 binary_sensor:
   - platform: gpio
@@ -142,6 +170,19 @@ binary_sensor:
       else {
         return id(occupancy).state;
       }
+  - platform: template
+    name: "Target 1 Active" # Don't change
+    disabled_by_default: False
+  - platform: template
+    name: "Target 2 Active" # Don't change
+    disabled_by_default: True
+  - platform: template
+    name: "Target 3 Active" # Don't change
+    disabled_by_default: True
+  - platform: template
+    name: "Target 4 Active" # Don't change
+    disabled_by_default: True
+
 uart:
   id: uart_bus
   tx_pin: GPIO13


### PR DESCRIPTION
This adds the ability to track the distance to up to 4 targets (does not try to be clever and filter by highest SNR this time).

This provides 3 new entities, distance to target, target SNR (signal to noise ratio) and target active/inactive.

Be aware that one person can have multiple targets, because the sensor can sometimes see a hand or a leg as a target if it's moving, along with the body for example. It means that when walking, one person can have 4 targets. Targets to typically settle down once seated to just a single target.

This definitely needs some testing so feedback welcome!