### PR TITLE
Replace constants for PIR & Occupancy Delay with config Entities

### DIFF
--- a/everything-presence-one.yaml
+++ b/everything-presence-one.yaml
@@ -7,8 +7,6 @@ substitutions:
   humidity_offset: "5"
   temperature_update_interval: "60s"
   illuminance_update_interval: "30s"
-  pir_delay_off: "10s"
-  occupancy_delay_off: "15s"
   hidden_ssid: "false"
   factory_reset_disabled: "true"
   uart_target_output_disabled: "true"
@@ -124,13 +122,13 @@ binary_sensor:
     id: pir_motion_sensor
     device_class: motion
     filters:
-      - delayed_off: ${pir_delay_off}
+      - delayed_off:  !lambda 'return id(pir_off_latency).state * 1000.0;'
   - platform: template
     name: Occupancy
     id: occupancy
     device_class: occupancy
     filters:
-      - delayed_off: ${occupancy_delay_off}
+      - delayed_off: !lambda 'return id(occupancy_off_latency).state * 1000.0;'
     lambda: |-
       if ( id(mmwave).state or id(pir_motion_sensor).state) {
         return true;
@@ -310,6 +308,34 @@ number:
       - uart.write: "saveConfig"
       - delay: 1s
       - switch.turn_on: mmwave_sensor
+
+  - platform: template
+    name: Occupancy off latency
+    icon: mdi:clock-end
+    entity_category: config
+    id: occupancy_off_latency
+    min_value: 1
+    max_value: 60
+    initial_value: 15
+    optimistic: true
+    step: 1
+    restore_value: true
+    unit_of_measurement: seconds
+    mode: slider
+
+  - platform: template
+    name: PIR off latency
+    icon: mdi:clock-end
+    entity_category: config
+    id: pir_off_latency
+    min_value: 1
+    max_value: 60
+    initial_value: 10
+    optimistic: true
+    step: 1
+    restore_value: true
+    unit_of_measurement: seconds
+    mode: slider
 
   - platform: template
     name: "Temperature Offset"

--- a/everything-presence-one.yaml
+++ b/everything-presence-one.yaml
@@ -2,7 +2,7 @@ substitutions:
   name: "everything-presence-one"
   friendly_name: "Everything Presence One"
   project_name: "Everything Smart Technology.Everything Presence One"
-  project_version: "1.1.6"
+  project_version: "1.1.7"
   temperature_offset: "-3"
   humidity_offset: "5"
   temperature_update_interval: "60s"


### PR DESCRIPTION
I added two new number entities to configure the PIR and Occupancy delay in the UI to make changes for new users more comfortable.