### PR TITLE
Merge target distance into main YAML

### DIFF
--- a/everything-presence-one-beta.yaml
+++ b/everything-presence-one-beta.yaml
@@ -182,13 +182,87 @@ binary_sensor:
   - platform: template
     name: "Target 4 Active" # Don't change
     disabled_by_default: True
+globals:
+  - id: last_target_count
+    type: int
+    restore_value: no
+    initial_value: '0'
 
 uart:
   id: uart_bus
   tx_pin: GPIO13
   rx_pin: GPIO14
   baud_rate: 115200
+  debug:
+    direction: BOTH
+    dummy_receiver: True
+    after:
+      delimiter: "*\r\n"
+    sequence:
+        - lambda: |-
+            UARTDebug::log_string(direction, bytes);
 
+            const int max_targets = 4;
+            static float t_distance[max_targets] = {0.0};
+            static float t_snr[max_targets] = {0.0};
+            static bool t_active[max_targets] = {false};
+
+            std::string line(bytes.begin(), bytes.end());
+
+            if (line.substr(0, 6) == "$JYRPO") {
+                size_t pos = 0;
+                std::vector<std::string> v;
+                std::string token;
+                std::string s = line.substr(7);
+
+                while ((pos = s.find(",")) != std::string::npos) {
+                    token = s.substr(0, pos);
+                    v.push_back(token);
+                    s.erase(0, pos + 1);
+                }
+                v.push_back(s);
+
+                int target_count = atoi(v[0].c_str());
+                int target_index = atoi(v[1].c_str()) - 1;
+                float target_distance_val = atof(v[2].c_str());
+                float target_snr_val = atof(v[4].c_str());
+
+                ESP_LOGD("UART", "Target Count: %d, Target Index: %d", target_count, target_index);
+
+                if (id(last_target_count) != target_count) {
+                    // Reset all targets to inactive
+                    for (int i = 0; i < max_targets; i++) {
+                        t_active[i] = false;
+                        t_distance[i] = 0.0;
+                        t_snr[i] = 0.0;
+                    }
+                    id(last_target_count) = target_count;
+                }
+
+                if (target_index < max_targets) {
+                    t_distance[target_index] = target_distance_val;
+                    t_snr[target_index] = target_snr_val;
+                    t_active[target_index] = true;
+                }
+
+                if (target_index == target_count - 1) {
+                    id(target_distance_1_m).publish_state(t_distance[0]);
+                    id(target_1_snr).publish_state(t_snr[0]);
+                    id(target_1_active).publish_state(t_active[0]);
+
+                    id(target_distance_2_m).publish_state(t_distance[1]);
+                    id(target_2_snr).publish_state(t_snr[1]);
+                    id(target_2_active).publish_state(t_active[1]);
+
+                    id(target_distance_3_m).publish_state(t_distance[2]);
+                    id(target_3_snr).publish_state(t_snr[2]);
+                    id(target_3_active).publish_state(t_active[2]);
+
+                    id(target_distance_4_m).publish_state(t_distance[3]);
+                    id(target_4_snr).publish_state(t_snr[3]);
+                    id(target_4_active).publish_state(t_active[3]);
+                }
+            }
 
 switch:
   - platform: template
@@ -574,8 +648,3 @@ text_sensor:
   - platform: template
     name: "Distance Zones Status"
     id: "distance_zone_status"
-
-custom_component:
-- lambda: |-
-    auto my_custom = new Sen0395Distance(id(uart_bus));
-    return {my_custom};

--- a/everything-presence-one-beta.yaml
+++ b/everything-presence-one-beta.yaml
@@ -21,8 +21,6 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
-  includes:
-    - SEN0395_distance.h
 
 esp32:
   board: esp32dev
@@ -127,15 +125,19 @@ sensor:
   - platform: template
     name: "Target 1 SNR" # Don't change
     disabled_by_default: True
+    id: target_1_snr
   - platform: template
     name: "Target 2 SNR" # Don't change
     disabled_by_default: True
+    id: target_2_snr
   - platform: template
     name: "Target 3 SNR" # Don't change
     disabled_by_default: True
+    id: target_3_snr
   - platform: template
     name: "Target 4 SNR" # Don't change
     disabled_by_default: True
+    id: target_4_snr
 
 binary_sensor:
   - platform: gpio
@@ -173,15 +175,19 @@ binary_sensor:
   - platform: template
     name: "Target 1 Active" # Don't change
     disabled_by_default: False
+    id: target_1_active
   - platform: template
     name: "Target 2 Active" # Don't change
     disabled_by_default: True
+    id: target_2_active
   - platform: template
     name: "Target 3 Active" # Don't change
     disabled_by_default: True
+    id: target_3_active
   - platform: template
     name: "Target 4 Active" # Don't change
     disabled_by_default: True
+    id: target_4_active
 globals:
   - id: last_target_count
     type: int


### PR DESCRIPTION
The issue with the current beta is that there is no way to remotely include the header file which handles the target distance. See [96](https://github.com/EverythingSmartHome/everything-presence-one/issues/96)

This PR adds the code from that header file into the main YAML so there should be no problem with updates in the future.