### PR TITLE
Re-add improv_ble

### DIFF
--- a/everything-presence-one-beta.yaml
+++ b/everything-presence-one-beta.yaml
@@ -37,6 +37,9 @@ wifi:
 
 improv_serial:
 
+esp32_improv:
+  authorizer: none
+
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-beta.yaml@main
   import_full_config: false


### PR DESCRIPTION
Re-add the improv_ble feature to allow the EP1 to be configured via bluetooth