### PR TITLE
Change framework to ESP-IDF

### DIFF
--- a/everything-presence-one-beta.yaml
+++ b/everything-presence-one-beta.yaml
@@ -24,6 +24,8 @@ esphome:
 
 esp32:
   board: esp32dev
+  framework:
+    type: esp-idf
 
 logger:
 


### PR DESCRIPTION
This PR changes the base framework the EP1 uses from the default Arduino to ESP-IDF.

ESP-IDF seems to run much better particularly regarding WiFi and BLE being active at the same time and when trying to update over wireless which can sometimes timeout with Arduino framework.

The flash size was also getting a bit tight given all the components that are active, so this also reduces the flash size from 87.6% down to 69.4%. Nice.