### PR TITLE
Change step for on latency

### DIFF
--- a/everything-presence-one-beta.yaml
+++ b/everything-presence-one-beta.yaml
@@ -519,10 +519,10 @@ number:
     id: mmwave_on_latency
     entity_category: config
     min_value: 0
-    max_value: 60
+    max_value: 2
     initial_value: 0
     optimistic: true
-    step: 0.5
+    step: 0.25
     restore_value: true
     unit_of_measurement: seconds
     mode: slider

--- a/everything-presence-one.yaml
+++ b/everything-presence-one.yaml
@@ -272,10 +272,10 @@ number:
     id: mmwave_on_latency
     entity_category: config
     min_value: 0
-    max_value: 60
+    max_value: 2
     initial_value: 0
     optimistic: true
-    step: 0.5
+    step: 0.25
     restore_value: true
     unit_of_measurement: seconds
     mode: slider


### PR DESCRIPTION
This PR changes the step for the mmWave on latency to be 25ms instead of 50ms so you can get more granular control, and also reduces the maximum on latency from 60s to 2s as there shouldn't be a need for more than 2s really.