### PR TITLE
Fix unit of measurement on target distance

### DIFF
--- a/everything-presence-one-beta.yaml
+++ b/everything-presence-one-beta.yaml
@@ -112,21 +112,29 @@ sensor:
     id: target_distance_1_m
     accuracy_decimals: 2
     disabled_by_default: false
+    device_class: distance
+    unit_of_measurement: "m"
   - platform: template
     name: Target 2 Distance # Don't change
     id: target_distance_2_m
     accuracy_decimals: 2
     disabled_by_default: True
+    device_class: distance
+    unit_of_measurement: "m"
   - platform: template
     name: Target 3 Distance # Don't change
     id: target_distance_3_m
     accuracy_decimals: 2
     disabled_by_default: True
+    device_class: distance
+    unit_of_measurement: "m"
   - platform: template
     name: Target 4 Distance # Don't change
     id: target_distance_4_m
     accuracy_decimals: 2
     disabled_by_default: True
+    device_class: distance
+    unit_of_measurement: "m"
   - platform: template
     name: "Target 1 SNR" # Don't change
     disabled_by_default: True


### PR DESCRIPTION
This fixes the unit of measurement and the device class on the target X m entities so that they show up correctly in meters and also in a graph in Home Assistant, rather than a bar chart.