### PR TITLE
Add ESPHome factory_reset button

### DIFF
--- a/everything-presence-one-beta.yaml
+++ b/everything-presence-one-beta.yaml
@@ -719,6 +719,8 @@ button:
       - uart.write: "resetCfg"
       - delay: 3s
       - switch.turn_on: mmwave_sensor
+  - platform: factory_reset
+    name: Factory reset
   - platform: template
     name: mmWave Set Distance
     id: mmwave_set_distance

--- a/everything-presence-one-st.yaml
+++ b/everything-presence-one-st.yaml
@@ -363,3 +363,5 @@ button:
       - uart.write: "resetCfg"
       - delay: 3s
       - switch.turn_on: mmwave_sensor
+  - platform: factory_reset
+    name: Factory reset

--- a/everything-presence-one.yaml
+++ b/everything-presence-one.yaml
@@ -462,3 +462,5 @@ button:
       - uart.write: "resetCfg"
       - delay: 3s
       - switch.turn_on: mmwave_sensor
+  - platform: factory_reset
+    name: Factory reset


### PR DESCRIPTION
Using the "Factory reset" button you can easily reset your EP1 values (e.g. mmWave distance, mmWave on latency) to the factory default ones.