### PR TITLE
Make LED visible by default

### DIFF
--- a/everything-presence-one-beta.yaml
+++ b/everything-presence-one-beta.yaml
@@ -56,13 +56,13 @@ light:
     name: ESP32 status LED
     pin: GPIO32
     entity_category: config
-    disabled_by_default: True
+    disabled_by_default: False
   - platform: binary
     name: mmWave LED
     restore_mode: RESTORE_DEFAULT_OFF
     output: mmwave_led_output
     entity_category: config
-    disabled_by_default: True
+    disabled_by_default: False
 
 output:
   - platform: template

--- a/everything-presence-one.yaml
+++ b/everything-presence-one.yaml
@@ -54,13 +54,13 @@ light:
     name: ESP32 status LED
     pin: GPIO32
     entity_category: config
-    disabled_by_default: True
+    disabled_by_default: False
   - platform: binary
     name: mmWave LED
     restore_mode: RESTORE_DEFAULT_OFF
     output: mmwave_led_output
     entity_category: config
-    disabled_by_default: True
+    disabled_by_default: False
 
 output:
   - platform: template


### PR DESCRIPTION
Make the ESP32 LED and mmWave LED visible by default - I get asked frequently why a user can't find the LED controls in Home Assistant, which should hopefully help.