### PR TITLE
Fix negative light sensor values

### DIFF
--- a/everything-presence-one-beta.yaml
+++ b/everything-presence-one-beta.yaml
@@ -149,6 +149,8 @@ sensor:
             - 79.8 -> 197.1
             - 84.3 -> 205.7 
       - lambda: "return x + id(illuminance_offset_ui).state;"
+      - clamp:
+          min_value: 0
 
   - platform: template
     name: Target 1 Distance # Don't change

--- a/everything-presence-one-st.yaml
+++ b/everything-presence-one-st.yaml
@@ -107,6 +107,9 @@ sensor:
             - 71.5 -> 176.9
             - 79.8 -> 197.1
             - 84.3 -> 205.7
+      - clamp:
+          min_value: 0
+
 
 binary_sensor:
   - platform: gpio

--- a/everything-presence-one.yaml
+++ b/everything-presence-one.yaml
@@ -147,6 +147,8 @@ sensor:
             - 79.8 -> 197.1
             - 84.3 -> 205.7 
       - lambda: "return x + id(illuminance_offset_ui).state;"
+      - clamp:
+          min_value: 0
 
 binary_sensor:
   - platform: gpio


### PR DESCRIPTION
Fix negative light sensor values (a side effect of adding calibrated light sensor data) by clamping the minimum to 0.