### PR TITLE
Ensure sensor start after boot

### DIFF
--- a/everything-presence-one-beta.yaml
+++ b/everything-presence-one-beta.yaml
@@ -2,7 +2,7 @@ substitutions:
   name: "everything-presence-beta"
   friendly_name: "Everything Presence One"
   project_name: "Everything Smart Technology.Everything Presence One"
-  project_version: "1.3.2b"
+  project_version: "1.3.3b"
   temperature_offset: "-3"
   humidity_offset: "5"
   temperature_update_interval: "60s"
@@ -21,6 +21,10 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  on_boot:
+    priority: 600
+    then:
+      - uart.write: "sensorStart"
 
 esp32:
   board: esp32dev

--- a/everything-presence-one-st.yaml
+++ b/everything-presence-one-st.yaml
@@ -3,7 +3,7 @@ substitutions:
   room: ""
   friendly_name: "Everything Presence One ST"
   project_name: "Everything Smart Technology.Everything Presence One"
-  project_version: "1.1.9s"
+  project_version: "1.1.10s"
   temperature_offset: "-3"
   humidity_offset: "5"
   temperature_update_interval: "60s"
@@ -21,6 +21,10 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  on_boot:
+    priority: 600
+    then:
+      - uart.write: "sensorStart"
 
 esp32:
   board: esp32dev

--- a/everything-presence-one.yaml
+++ b/everything-presence-one.yaml
@@ -2,7 +2,7 @@ substitutions:
   name: "everything-presence-one"
   friendly_name: "Everything Presence One"
   project_name: "Everything Smart Technology.Everything Presence One"
-  project_version: "1.1.9"
+  project_version: "1.1.10"
   temperature_offset: "-3"
   humidity_offset: "5"
   temperature_update_interval: "60s"
@@ -19,6 +19,10 @@ esphome:
   project:
     name: ${project_name}
     version: ${project_version}
+  on_boot:
+    priority: 600
+    then:
+      - uart.write: "sensorStart"
 
 esp32:
   board: esp32dev


### PR DESCRIPTION
Adds a quick hack to ensure that sensor startsup after boot which some users seem to report is an issue in later versions of ESPHome, where the mmWave LED is on solid, and detection does not work.