### PR TITLE
ESPHome OTA - Separate OTABackend from OTA component

### DIFF
--- a/common/everything-presence-one-base.yaml
+++ b/common/everything-presence-one-base.yaml
@@ -22,6 +22,7 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 wifi:
   fast_connect: ${hidden_ssid}

--- a/everything-presence-one-st-sen0609.yaml
+++ b/everything-presence-one-st-sen0609.yaml
@@ -32,6 +32,7 @@ esp32:
 logger:
 
 ota:
+  - platform: esphome
 
 web_server:
 

--- a/everything-presence-one-st.yaml
+++ b/everything-presence-one-st.yaml
@@ -32,6 +32,7 @@ esp32:
 logger:
 
 ota:
+  - platform: esphome
 
 web_server:
 


### PR DESCRIPTION
Add 'platform: esphome' to device yaml, so OTA component now reads as:

```
ota:
  - platform: esphome
```
In line with changes made by https://github.com/esphome/esphome/pull/6459