### PR TITLE
Add update entity to Everything Presence One

### DIFF
--- a/common/everything-presence-one-base.yaml
+++ b/common/everything-presence-one-base.yaml
@@ -23,6 +23,11 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
+  - platform: http_request
+    id: ota_http_request
+
+http_request:
 
 wifi:
   fast_connect: ${hidden_ssid}

--- a/everything-presence-one-beta-ble.yaml
+++ b/everything-presence-one-beta-ble.yaml
@@ -2,7 +2,7 @@ substitutions:
   name: "everything-presence-one"
   friendly_name: "Everything Presence One"
   project_name: "Everything Smart Technology.Everything Presence One"
-  project_version: "1.3.7b"
+  project_version: "1.3.8b"
   temperature_offset: "-3"
   humidity_offset: "5"
   temperature_update_interval: "60s"
@@ -12,6 +12,12 @@ substitutions:
   uart_target_output_disabled: "true"
   uart_presence_output_disabled: "true"
   log_level: "ERROR"
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware
+    source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-ble-beta-manifest.json
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-beta-ble.yaml@main

--- a/everything-presence-one-beta.yaml
+++ b/everything-presence-one-beta.yaml
@@ -2,7 +2,7 @@ substitutions:
   name: "everything-presence-one"
   friendly_name: "Everything Presence One"
   project_name: "Everything Smart Technology.Everything Presence One"
-  project_version: "1.3.7b"
+  project_version: "1.3.8b"
   temperature_offset: "-3"
   humidity_offset: "5"
   temperature_update_interval: "60s"
@@ -12,6 +12,12 @@ substitutions:
   uart_target_output_disabled: "true"
   uart_presence_output_disabled: "true"
   log_level: "ERROR"
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware
+    source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-beta-manifest.json
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-beta.yaml@main

--- a/everything-presence-one-ble.yaml
+++ b/everything-presence-one-ble.yaml
@@ -2,7 +2,7 @@ substitutions:
   name: "everything-presence-one"
   friendly_name: "Everything Presence One"
   project_name: "Everything Smart Technology.Everything Presence One"
-  project_version: "1.2.3"
+  project_version: "1.2.4"
   temperature_offset: "-3"
   humidity_offset: "5"
   temperature_update_interval: "60s"
@@ -12,6 +12,12 @@ substitutions:
   uart_target_output_disabled: "true"
   uart_presence_output_disabled: "true"
   log_level: "ERROR"
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware
+    source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ble-manifest.json
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-ble.yaml@main

--- a/everything-presence-one-sen0609-ble.yaml
+++ b/everything-presence-one-sen0609-ble.yaml
@@ -2,7 +2,7 @@ substitutions:
   name: "everything-presence-one"
   friendly_name: "Everything Presence One"
   project_name: "Everything Smart Technology.Everything Presence One"
-  project_version: "1.2.3"
+  project_version: "1.2.4"
   temperature_offset: "-3"
   humidity_offset: "5"
   temperature_update_interval: "60s"
@@ -12,6 +12,12 @@ substitutions:
   uart_target_output_disabled: "true"
   uart_presence_output_disabled: "true"
   log_level: "ERROR"
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware
+    source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-sen0609-ble-manifest.json
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-sen0609-ble.yaml@main

--- a/everything-presence-one-sen0609.yaml
+++ b/everything-presence-one-sen0609.yaml
@@ -2,7 +2,7 @@ substitutions:
   name: "everything-presence-one"
   friendly_name: "Everything Presence One"
   project_name: "Everything Smart Technology.Everything Presence One"
-  project_version: "1.2.3"
+  project_version: "1.2.4"
   temperature_offset: "-3"
   humidity_offset: "5"
   temperature_update_interval: "60s"
@@ -12,6 +12,12 @@ substitutions:
   uart_target_output_disabled: "true"
   uart_presence_output_disabled: "true"
   log_level: "ERROR"
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware
+    source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-sen0609-manifest.json
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-sen0609.yaml@main

--- a/everything-presence-one-st-sen0609.yaml
+++ b/everything-presence-one-st-sen0609.yaml
@@ -3,7 +3,7 @@ substitutions:
   room: ""
   friendly_name: "Everything Presence One ST"
   project_name: "Everything Smart Technology.Everything Presence One"
-  project_version: "1.2.3s"
+  project_version: "1.2.4s"
   temperature_offset: "-3"
   humidity_offset: "5"
   temperature_update_interval: "60s"

--- a/everything-presence-one-st.yaml
+++ b/everything-presence-one-st.yaml
@@ -3,7 +3,7 @@ substitutions:
   room: ""
   friendly_name: "Everything Presence One ST"
   project_name: "Everything Smart Technology.Everything Presence One"
-  project_version: "1.1.10s"
+  project_version: "1.1.11s"
   temperature_offset: "-3"
   humidity_offset: "5"
   temperature_update_interval: "60s"

--- a/everything-presence-one.yaml
+++ b/everything-presence-one.yaml
@@ -2,7 +2,7 @@ substitutions:
   name: "everything-presence-one"
   friendly_name: "Everything Presence One"
   project_name: "Everything Smart Technology.Everything Presence One"
-  project_version: "1.2.3"
+  project_version: "1.2.4"
   temperature_offset: "-3"
   humidity_offset: "5"
   temperature_update_interval: "60s"
@@ -12,6 +12,12 @@ substitutions:
   uart_target_output_disabled: "true"
   uart_presence_output_disabled: "true"
   log_level: "ERROR"
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware
+    source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-manifest.json
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one.yaml@main


### PR DESCRIPTION
This release mainly adds support for the new update entities in ESPHome. After updating, you will get a new "Firmware" update entity in Home Assistant which allows you to know when a new update is available from this GitHub repo. It also lets you update directly from here, without needing the ESPHome add-on to compile it for you.