### PR TITLE
Disable manufacturer updates by default

### DIFF
--- a/common/everything-presence-one-base.yaml
+++ b/common/everything-presence-one-base.yaml
@@ -28,7 +28,6 @@ ota:
     id: ota_http_request
 
 http_request:
-  timeout: 4s
 
 wifi:
   fast_connect: ${hidden_ssid}

--- a/everything-presence-one-beta-ble.yaml
+++ b/everything-presence-one-beta-ble.yaml
@@ -16,8 +16,9 @@ substitutions:
 update:
   - platform: http_request
     id: update_http_request
-    name: Firmware
+    name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-ble-beta-manifest.json
+    disabled_by_default: true
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-beta-ble.yaml@main

--- a/everything-presence-one-beta.yaml
+++ b/everything-presence-one-beta.yaml
@@ -16,8 +16,9 @@ substitutions:
 update:
   - platform: http_request
     id: update_http_request
-    name: Firmware
+    name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-beta-manifest.json
+    disabled_by_default: true
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-beta.yaml@main

--- a/everything-presence-one-ble.yaml
+++ b/everything-presence-one-ble.yaml
@@ -16,8 +16,9 @@ substitutions:
 update:
   - platform: http_request
     id: update_http_request
-    name: Firmware
+    name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ble-manifest.json
+    disabled_by_default: true
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-ble.yaml@main

--- a/everything-presence-one-sen0609-ble.yaml
+++ b/everything-presence-one-sen0609-ble.yaml
@@ -16,8 +16,9 @@ substitutions:
 update:
   - platform: http_request
     id: update_http_request
-    name: Firmware
+    name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-sen0609-ble-manifest.json
+    disabled_by_default: true
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-sen0609-ble.yaml@main

--- a/everything-presence-one-sen0609.yaml
+++ b/everything-presence-one-sen0609.yaml
@@ -16,8 +16,9 @@ substitutions:
 update:
   - platform: http_request
     id: update_http_request
-    name: Firmware
+    name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-sen0609-manifest.json
+    disabled_by_default: true
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-sen0609.yaml@main

--- a/everything-presence-one.yaml
+++ b/everything-presence-one.yaml
@@ -16,8 +16,9 @@ substitutions:
 update:
   - platform: http_request
     id: update_http_request
-    name: Firmware
+    name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-manifest.json
+    disabled_by_default: true
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one.yaml@main


### PR DESCRIPTION
This changes the new manufacturer update entity to disabled by default, so that it is hidden. This is due to many users getting confused at the difference between the ESPHome update entity and the new manufacturer update entity. This has caused them to overwrite their encryption key and thus Home Assistant isn't able to communicate with the device.

Until their is a better way to handle the manufacturer updates when an encryption key is set, I will disable it for now to not cause so much confusion.

It also removes the http_request timeout that was set in a previous version to help with an esphome bug. The timeout in ESPHome is now 4.5s by default.