### PR TITLE
Fix firmware selector only allowing bluetooth firmware

### DIFF
--- a/static/updating.md
+++ b/static/updating.md
@@ -365,7 +365,7 @@ document.addEventListener("DOMContentLoaded", function() {
                 baseName += "-beta";
             }
 
-            if (firmware.includes("Bluetooth")) {
+            if (firmware === "Bluetooth") {
                 baseName += "-ble";
             }
 


### PR DESCRIPTION
Fix a bug where the firmware selector on the update page would always give a bluetooth firmware even when non ble was selected