### PR TITLE
Factory_reset

### DIFF
--- a/common/everything-presence-one-base.yaml
+++ b/common/everything-presence-one-base.yaml
@@ -144,6 +144,25 @@ binary_sensor:
       else {
         return id(occupancy).state;
       }
+  - platform: gpio
+    pin:
+      number: 0
+      inverted: true
+    id: flash_button
+    internal: True
+    on_multi_click:
+      - timing:
+        - ON for at least 10s
+        then:
+          - repeat: 
+              count: 5
+              then:
+                - light.turn_on: esp32_led
+                - delay: 150ms
+                - light.turn_off: esp32_led
+                - delay: 150ms
+          - light.turn_on: esp32_led
+          - button.press: factory_reset_button
 
 number:
   - platform: template
@@ -233,3 +252,6 @@ button:
     name: Safe mode
     entity_category: config
     disabled_by_default: True
+  - platform: factory_reset
+    id: "factory_reset_button"
+    internal: True

--- a/common/everything-presence-one-base.yaml
+++ b/common/everything-presence-one-base.yaml
@@ -45,6 +45,7 @@ i2c:
 light:
   - platform: status_led
     name: ESP32 status LED
+    id: esp32_led
     pin: GPIO32
     entity_category: config
     disabled_by_default: False


### PR DESCRIPTION
Add factory reset button to allow to easily factory reset the device without needing access to a computer to flash again.

Done by holding the "boot" button for 10s, the RED LED will blink 5 times and the reset is complete.