### PR TITLE
Fix strapping warning on flash button

### DIFF
--- a/common/everything-presence-one-base.yaml
+++ b/common/everything-presence-one-base.yaml
@@ -151,6 +151,7 @@ binary_sensor:
     pin:
       number: 0
       inverted: true
+      ignore_strapping_warning: True
     id: flash_button
     internal: True
     filters:


### PR DESCRIPTION
When compiling ESPHome displays a warning about GPIO0 being a strapping pin. This pull request ignores that warning