### PR TITLE
Replace `/` with `⁄` (Unicode FRACTION SLASH) in sen0609-common.yaml

### DIFF
--- a/common/sen0609-common.yaml
+++ b/common/sen0609-common.yaml
@@ -245,7 +245,7 @@ select:
             - switch.turn_off: uart_target_output
 
   - platform: template
-    name: "Distance/Speed Update Rate"
+    name: "Distance⁄Speed Update Rate"
     id: mmwave_update_rate
     entity_category: config
     icon: mdi:timer


### PR DESCRIPTION
ESPHome warns that 

```
WARNING 'Distance/Speed Update Rate' contains '/' which is reserved as a URL path separator. Automatically replacing with 'Distance⁄Speed Update Rate' (Unicode FRACTION SLASH). Please update your configuration. This will become an error in ESPHome 2026.7.0.
```

Fixes #306