### PR TITLE
Fix checking of updates when BLE is enabled

### DIFF
--- a/common/bluetooth-base.yaml
+++ b/common/bluetooth-base.yaml
@@ -7,3 +7,61 @@ bluetooth_proxy:
 
 esp32_improv:
   authorizer: none
+
+# BLE consumes ~80KB of heap, causing TLS cert verification to fail (MPI alloc
+# error 0x4290) during HTTPS firmware update checks. BLE is delayed on boot so
+# the update check has enough memory, then enabled once the check completes.
+# If no WiFi credentials are configured (first-time setup), BLE is enabled
+# immediately so Bluetooth Improv can be used to configure WiFi.
+esp32_ble:
+  enable_on_boot: false
+
+esphome:
+  on_boot:
+    priority: -100
+    then:
+      - if:
+          condition:
+            lambda: 'return !wifi::global_wifi_component->has_sta();'
+          then:
+            - logger.log: "No WiFi credentials configured, enabling BLE for Improv setup"
+            - ble.enable
+
+wifi:
+  on_connect:
+    - delay: 15s
+    - ble.disable
+    - delay: 5s
+    - component.update: update_http_request
+    - delay: 10s
+    - lambda: |-
+        if (id(update_http_request).status_has_error()) {
+          id(update_http_request).status_clear_error();
+        }
+    - ble.enable
+
+interval:
+  # Clear stuck error flags from externally-triggered update checks (e.g. HA
+  # "check for updates" button) that fail because BLE is running.
+  - interval: 30s
+    then:
+      - lambda: |-
+          if (id(update_http_request).status_has_error()) {
+            id(update_http_request).status_clear_error();
+          }
+  # Periodic update check with BLE disabled for TLS to succeed.
+  - interval: 6h
+    then:
+      - if:
+          condition:
+            wifi.connected:
+          then:
+            - ble.disable
+            - delay: 5s
+            - component.update: update_http_request
+            - delay: 10s
+            - lambda: |-
+                if (id(update_http_request).status_has_error()) {
+                  id(update_http_request).status_clear_error();
+                }
+            - ble.enable

--- a/common/everything-presence-one-base.yaml
+++ b/common/everything-presence-one-base.yaml
@@ -26,6 +26,8 @@ esp32:
   board: esp32dev
   framework:
     type: esp-idf
+    advanced:
+      sram1_as_iram: true
 
 # Enable logging
 logger:
@@ -39,12 +41,25 @@ api:
       then:
         - lambda: |-
             ESP_LOGI("fw", "Setting update manifest URL: %s", url.c_str());
+            #ifdef USE_ESP32_BLE
+            if (esp32_ble::global_ble && esp32_ble::global_ble->is_active()) {
+              ESP_LOGI("fw", "Disabling BLE for firmware update");
+              esp32_ble::global_ble->disable();
+            }
+            #endif
             id(update_http_request).set_source_url(url);
+        - delay: 5s
         - component.update: update_http_request
         - delay: 1s
         - update.perform:
             id: update_http_request
             force_update: true
+        - lambda: |-
+            #ifdef USE_ESP32_BLE
+            if (esp32_ble::global_ble) {
+              esp32_ble::global_ble->enable();
+            }
+            #endif
     - action: get_build_flags
       then:
         - api.respond:
@@ -69,17 +84,6 @@ wifi:
   fast_connect: ${hidden_ssid}
   on_connect:
     - switch.turn_on: mmwave_sensor
-    # Workaround: ESPHome 2026.4.1+ correctly persists component error flags (PR #15658),
-    # but http_request.update never clears its error after a failed manifest fetch,
-    # leaving the status LED blinking indefinitely.
-    - repeat:
-        count: 12
-        then:
-          - delay: 5s
-          - lambda: |-
-              if (id(update_http_request).status_has_error()) {
-                id(update_http_request).status_clear_error();
-              }
 
 improv_serial:
 
@@ -349,6 +353,15 @@ button:
     entity_category: diagnostic
     on_press:
       - logger.log: "Applying firmware update based on selected configuration"
+      # Disable BLE if running — TLS needs the heap BLE consumes
+      - lambda: |-
+          #ifdef USE_ESP32_BLE
+          if (esp32_ble::global_ble && esp32_ble::global_ble->is_active()) {
+            ESP_LOGI("firmware", "Disabling BLE for firmware update");
+            esp32_ble::global_ble->disable();
+          }
+          #endif
+      - delay: 5s
       - lambda: |-
           std::string base_url = "https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-";
           base_url += "${device_config.sensor_variant}";
@@ -386,6 +399,14 @@ button:
       - update.perform:
           id: update_http_request
           force_update: true
+      # Re-enable BLE if it was available
+      - lambda: |-
+          #ifdef USE_ESP32_BLE
+          if (esp32_ble::global_ble) {
+            ESP_LOGI("firmware", "Re-enabling BLE after firmware update");
+            esp32_ble::global_ble->enable();
+          }
+          #endif
   - platform: safe_mode
     internal: false
     name: Safe mode

--- a/everything-presence-one-beta-ble-co2-rev1.3.yaml
+++ b/everything-presence-one-beta-ble-co2-rev1.3.yaml
@@ -27,6 +27,7 @@ update:
     name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-sen0395-co2-ble-rev1-3-beta-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-beta-ble-co2-rev1.3.yaml@main

--- a/everything-presence-one-beta-ble-co2-rev1.6.yaml
+++ b/everything-presence-one-beta-ble-co2-rev1.6.yaml
@@ -27,6 +27,7 @@ update:
     name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-sen0395-co2-ble-rev1-6-beta-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-beta-ble-co2-rev1.6.yaml@main

--- a/everything-presence-one-beta-ble-co2.yaml
+++ b/everything-presence-one-beta-ble-co2.yaml
@@ -27,6 +27,7 @@ update:
     name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-sen0395-co2-ble-rev1-5-beta-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-beta-ble-co2.yaml@main

--- a/everything-presence-one-beta-ble-rev1.3.yaml
+++ b/everything-presence-one-beta-ble-rev1.3.yaml
@@ -27,6 +27,7 @@ update:
     name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-sen0395-nomodule-ble-rev1-3-beta-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-beta-ble-rev1.3.yaml@main

--- a/everything-presence-one-beta-ble-rev1.6.yaml
+++ b/everything-presence-one-beta-ble-rev1.6.yaml
@@ -27,6 +27,7 @@ update:
     name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-sen0395-nomodule-ble-rev1-6-beta-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-beta-ble-rev1.6.yaml@main

--- a/everything-presence-one-beta-ble.yaml
+++ b/everything-presence-one-beta-ble.yaml
@@ -27,6 +27,7 @@ update:
     name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-sen0395-nomodule-ble-rev1-5-beta-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-beta-ble.yaml@main

--- a/everything-presence-one-ble-co2-rev1.3.yaml
+++ b/everything-presence-one-ble-co2-rev1.3.yaml
@@ -27,6 +27,7 @@ update:
     name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-sen0395-co2-ble-rev1-3-stable-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-ble-co2-rev1.3.yaml@main

--- a/everything-presence-one-ble-co2-rev1.6.yaml
+++ b/everything-presence-one-ble-co2-rev1.6.yaml
@@ -27,6 +27,7 @@ update:
     name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-sen0395-co2-ble-rev1-6-stable-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-ble-co2-rev1.6.yaml@main

--- a/everything-presence-one-ble-co2.yaml
+++ b/everything-presence-one-ble-co2.yaml
@@ -27,6 +27,7 @@ update:
     name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-sen0395-co2-ble-rev1-5-stable-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-ble-co2.yaml@main

--- a/everything-presence-one-ble-rev1.3.yaml
+++ b/everything-presence-one-ble-rev1.3.yaml
@@ -27,6 +27,7 @@ update:
     name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-sen0395-nomodule-ble-rev1-3-stable-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-ble-rev1.3.yaml@main

--- a/everything-presence-one-ble-rev1.6.yaml
+++ b/everything-presence-one-ble-rev1.6.yaml
@@ -27,6 +27,7 @@ update:
     name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-sen0395-nomodule-ble-rev1-6-stable-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-ble-rev1.6.yaml@main

--- a/everything-presence-one-ble.yaml
+++ b/everything-presence-one-ble.yaml
@@ -27,6 +27,7 @@ update:
     name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-sen0395-nomodule-ble-rev1-5-stable-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-ble.yaml@main

--- a/everything-presence-one-sen0609-ble-co2-rev1.6.yaml
+++ b/everything-presence-one-sen0609-ble-co2-rev1.6.yaml
@@ -27,6 +27,7 @@ update:
     name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-sen0609-co2-ble-rev1-6-stable-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-sen0609-ble-co2-rev1.6.yaml@main

--- a/everything-presence-one-sen0609-ble-co2.yaml
+++ b/everything-presence-one-sen0609-ble-co2.yaml
@@ -27,6 +27,7 @@ update:
     name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-sen0609-co2-ble-rev1-5-stable-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-sen0609-ble-co2.yaml@main

--- a/everything-presence-one-sen0609-ble-rev1.6.yaml
+++ b/everything-presence-one-sen0609-ble-rev1.6.yaml
@@ -27,6 +27,7 @@ update:
     name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-sen0609-nomodule-ble-rev1-6-stable-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-sen0609-ble-rev1.6.yaml@main

--- a/everything-presence-one-sen0609-ble.yaml
+++ b/everything-presence-one-sen0609-ble.yaml
@@ -27,6 +27,7 @@ update:
     name: Everything Presence One Firmware
     source: https://everythingsmarthome.github.io/everything-presence-one/everything-presence-one-ha-sen0609-nomodule-ble-rev1-5-stable-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-one/everything-presence-one-sen0609-ble.yaml@main


### PR DESCRIPTION
Fix an issue where checking for updates fails (thus causing a flashing LED constantly) when BLE is enabled. This PR disables BLE while the check for updates occurs then re-enables it again after

Fixes: #309