### PR TITLE
Fix deprecated select state usage

### DIFF
--- a/common/everything-presence-one-base.yaml
+++ b/common/everything-presence-one-base.yaml
@@ -367,7 +367,7 @@ button:
           base_url += "${device_config.sensor_variant}";
           base_url += "-";
 
-          if (id(firmware_co2).state == "Enabled") {
+          if (id(firmware_co2).current_option() == "Enabled") {
             base_url += "co2";
           } else {
             base_url += "nomodule";
@@ -375,7 +375,7 @@ button:
 
           base_url += "-";
 
-          if (id(firmware_ble).state == "Enabled") {
+          if (id(firmware_ble).current_option() == "Enabled") {
             base_url += "ble";
           } else {
             base_url += "noble";

--- a/common/sen0609-common.yaml
+++ b/common/sen0609-common.yaml
@@ -99,11 +99,11 @@ uart:
               
               // Get throttle interval from user setting
               uint32_t throttle_interval = 400; // Default 0.4s
-              if (id(mmwave_update_rate).state == "0.3s") {
+              if (id(mmwave_update_rate).current_option() == "0.3s") {
                 throttle_interval = 300;
-              } else if (id(mmwave_update_rate).state == "0.4s") {
+              } else if (id(mmwave_update_rate).current_option() == "0.4s") {
                 throttle_interval = 400;
-              } else if (id(mmwave_update_rate).state == "0.5s") {
+              } else if (id(mmwave_update_rate).current_option() == "0.5s") {
                 throttle_interval = 500;
               }
               
@@ -128,7 +128,7 @@ uart:
                 }
                 
                 // Update mmWave binary sensor based on target count when in distance mode
-                if (id(mmwave_mode).state == "Distance and Speed") {
+                if (id(mmwave_mode).current_option() == "Distance and Speed") {
                   id(mmwave).publish_state(target_count > 0);
                 }
                 
@@ -361,7 +361,7 @@ switch:
     turn_on_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Distance and Speed";'
+            lambda: 'return id(mmwave_mode).current_option() == "Distance and Speed";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -373,7 +373,7 @@ switch:
     turn_off_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Distance and Speed";'
+            lambda: 'return id(mmwave_mode).current_option() == "Distance and Speed";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -427,7 +427,7 @@ number:
     set_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Presence Detection";'
+            lambda: 'return id(mmwave_mode).current_option() == "Presence Detection";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -457,7 +457,7 @@ number:
     set_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Presence Detection";'
+            lambda: 'return id(mmwave_mode).current_option() == "Presence Detection";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -487,7 +487,7 @@ number:
     set_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Presence Detection";'
+            lambda: 'return id(mmwave_mode).current_option() == "Presence Detection";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -541,7 +541,7 @@ number:
     set_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Distance and Speed";'
+            lambda: 'return id(mmwave_mode).current_option() == "Distance and Speed";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -582,7 +582,7 @@ button:
     on_press:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Presence Detection";'
+            lambda: 'return id(mmwave_mode).current_option() == "Presence Detection";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s

--- a/everything-presence-one-st-sen0609-rev1.6.yaml
+++ b/everything-presence-one-st-sen0609-rev1.6.yaml
@@ -283,11 +283,11 @@ uart:
 
               // Get throttle interval from user setting
               uint32_t throttle_interval = 400; // Default 0.4s
-              if (id(mmwave_update_rate).state == "0.3s") {
+              if (id(mmwave_update_rate).current_option() == "0.3s") {
                 throttle_interval = 300;
-              } else if (id(mmwave_update_rate).state == "0.4s") {
+              } else if (id(mmwave_update_rate).current_option() == "0.4s") {
                 throttle_interval = 400;
-              } else if (id(mmwave_update_rate).state == "0.5s") {
+              } else if (id(mmwave_update_rate).current_option() == "0.5s") {
                 throttle_interval = 500;
               }
 
@@ -312,7 +312,7 @@ uart:
                 }
 
                 // Update mmWave binary sensor based on target count when in distance mode
-                if (id(mmwave_mode).state == "Distance and Speed") {
+                if (id(mmwave_mode).current_option() == "Distance and Speed") {
                   id(mmwave).publish_state(target_count > 0);
                 }
 
@@ -446,7 +446,7 @@ switch:
     turn_on_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Distance and Speed";'
+            lambda: 'return id(mmwave_mode).current_option() == "Distance and Speed";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -458,7 +458,7 @@ switch:
     turn_off_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Distance and Speed";'
+            lambda: 'return id(mmwave_mode).current_option() == "Distance and Speed";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -584,7 +584,7 @@ number:
     set_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Presence Detection";'
+            lambda: 'return id(mmwave_mode).current_option() == "Presence Detection";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -611,7 +611,7 @@ number:
     set_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Presence Detection";'
+            lambda: 'return id(mmwave_mode).current_option() == "Presence Detection";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -639,7 +639,7 @@ number:
     set_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Presence Detection";'
+            lambda: 'return id(mmwave_mode).current_option() == "Presence Detection";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -664,7 +664,7 @@ number:
     set_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Presence Detection";'
+            lambda: 'return id(mmwave_mode).current_option() == "Presence Detection";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -690,7 +690,7 @@ number:
     set_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Presence Detection";'
+            lambda: 'return id(mmwave_mode).current_option() == "Presence Detection";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -717,7 +717,7 @@ number:
     set_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Distance and Speed";'
+            lambda: 'return id(mmwave_mode).current_option() == "Distance and Speed";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s

--- a/everything-presence-one-st-sen0609.yaml
+++ b/everything-presence-one-st-sen0609.yaml
@@ -283,11 +283,11 @@ uart:
 
               // Get throttle interval from user setting
               uint32_t throttle_interval = 400; // Default 0.4s
-              if (id(mmwave_update_rate).state == "0.3s") {
+              if (id(mmwave_update_rate).current_option() == "0.3s") {
                 throttle_interval = 300;
-              } else if (id(mmwave_update_rate).state == "0.4s") {
+              } else if (id(mmwave_update_rate).current_option() == "0.4s") {
                 throttle_interval = 400;
-              } else if (id(mmwave_update_rate).state == "0.5s") {
+              } else if (id(mmwave_update_rate).current_option() == "0.5s") {
                 throttle_interval = 500;
               }
 
@@ -312,7 +312,7 @@ uart:
                 }
 
                 // Update mmWave binary sensor based on target count when in distance mode
-                if (id(mmwave_mode).state == "Distance and Speed") {
+                if (id(mmwave_mode).current_option() == "Distance and Speed") {
                   id(mmwave).publish_state(target_count > 0);
                 }
 
@@ -446,7 +446,7 @@ switch:
     turn_on_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Distance and Speed";'
+            lambda: 'return id(mmwave_mode).current_option() == "Distance and Speed";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -458,7 +458,7 @@ switch:
     turn_off_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Distance and Speed";'
+            lambda: 'return id(mmwave_mode).current_option() == "Distance and Speed";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -630,7 +630,7 @@ number:
     set_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Presence Detection";'
+            lambda: 'return id(mmwave_mode).current_option() == "Presence Detection";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -655,7 +655,7 @@ number:
     set_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Presence Detection";'
+            lambda: 'return id(mmwave_mode).current_option() == "Presence Detection";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -681,7 +681,7 @@ number:
     set_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Presence Detection";'
+            lambda: 'return id(mmwave_mode).current_option() == "Presence Detection";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -708,7 +708,7 @@ number:
     set_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Distance and Speed";'
+            lambda: 'return id(mmwave_mode).current_option() == "Distance and Speed";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s


### PR DESCRIPTION
Switch all `Select::state` accesses to `current_option()` across EP1, clearing the ESPHome deprecation warning and keeping the firmware building after `.state` is removed in 2026.7.0.

Touches 4 files, 35 lines:
- `common/everything-presence-one-base.yaml` - firmware-URL lambda (`firmware_ble`, `firmware_co2`)
- `common/sen0609-common.yaml` - `mmwave_mode` and `mmwave_update_rate` lambdas
- `everything-presence-one-st-sen0609.yaml` - standalone SEN0609 config (same patterns duplicated)
- `everything-presence-one-st-sen0609-rev1.6.yaml` - rev1.6 standalone SEN0609 config

Mirrors EverythingSmartHome/everything-presence-lite#431 (which closed EverythingSmartHome/everything-presence-lite#387), but with a wider sweep covering the sen0609 paths the original report didn't surface.

Binary sensor `.state` accesses (e.g. `id(mmwave).state == 0`, `id(pir_motion_sensor).state == 0`) are left as-is since that deprecation only applies to `select`.