### PR TITLE
Redirect legacy docs to Outline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 The Everything Presence One is a presence sensor for the smart home. It combines a mmWave sensor, motion sensor, light illuminance sensor, temperature and humidity sensor and integrates directly with [Home Assistant](https://www.home-assistant.io/) through [ESPHome](https://esphome.io/).
 
-The official user guide for the EP1 is located [here](https://docs.everythingsmart.io/s/products)!
+The official user guide for the EP1 is located [here](https://docs.everythingsmart.io/s/products/doc/everything-presence-one-ep1-3R178yZSUP)!
 
 ![Everything Presence One](static/images/assembly-insert-pir-sensor-3.jpg)

--- a/static/_includes/header_custom.html
+++ b/static/_includes/header_custom.html
@@ -1,9 +1,15 @@
-<meta property="og:url" content="https://everythingsmarthome.github.io/everything-presence-one/" />
+{% assign outline_docs_url = "https://docs.everythingsmart.io/s/products/doc/everything-presence-one-ep1-3R178yZSUP" %}
+<link rel="canonical" href="{{ outline_docs_url }}" />
+<meta http-equiv="refresh" content="0; url={{ outline_docs_url }}" />
+<script>
+  window.location.replace("{{ outline_docs_url }}");
+</script>
+<meta property="og:url" content="{{ outline_docs_url }}" />
 <meta property="og:type" content="website" />
-<meta property="og:description" content="User guide and documentation for the Everything Presence One." />
+<meta property="og:description" content="Everything Presence One documentation." />
 <meta property="og:image" content="https://everythingsmarthome.github.io/everything-presence-one/images/assembly-complete.jpg" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:site" content="@everysmarthome" />
-<meta name="twitter:title" content="Everything Presence One - User Guide" />
-<meta name="twitter:description" content="User guide and documentation for the Everything Presence One." />
+<meta name="twitter:title" content="Everything Presence One Documentation" />
+<meta name="twitter:description" content="Everything Presence One documentation." />
 <meta name="twitter:image" content="https://everythingsmarthome.github.io/everything-presence-one/images/assembly-complete.jpg" />


### PR DESCRIPTION
Redirect the legacy EP1 GitHub Pages docs to the current Outline docs landing page, and update the repo README to point at the maintained docs URL.