### PR TITLE
Fix $ escape

### DIFF
--- a/common/sen0609-common.yaml
+++ b/common/sen0609-common.yaml
@@ -27,7 +27,7 @@ uart:
               data += char(bytes[i]);
             }
             
-            // Parse presence detection data: $DFHPD,1,,,*
+            // Parse presence detection data: DFHPD,1,,,*
             if (data.find(std::string("$") + "DFHPD") == 0) {
               size_t comma1 = data.find(',', 6);
               if (comma1 != std::string::npos) {
@@ -91,7 +91,7 @@ uart:
               last_query_command = "";
             }
             
-            // Parse distance and speed data: $DFDMD,target_count,target_number,distance,speed,energy,,*
+            // Parse distance and speed data: DFDMD,target_count,target_number,distance,speed,energy,,*
             if (data.find(std::string("$") +"DFDMD") == 0) {
               // Throttling for distance/speed updates
               static uint32_t last_distance_update = 0;

--- a/common/sen0609-common.yaml
+++ b/common/sen0609-common.yaml
@@ -28,7 +28,7 @@ uart:
             }
             
             // Parse presence detection data: $DFHPD,1,,,*
-            if (data.find("$$DFHPD") == 0) {
+            if (data.find(std::string("$") + "DFHPD") == 0) {
               size_t comma1 = data.find(',', 6);
               if (comma1 != std::string::npos) {
                 std::string presence_str = data.substr(comma1 + 1, 1);
@@ -92,7 +92,7 @@ uart:
             }
             
             // Parse distance and speed data: $DFDMD,target_count,target_number,distance,speed,energy,,*
-            if (data.find("$$DFDMD") == 0) {
+            if (data.find(std::string("$") +"DFDMD") == 0) {
               // Throttling for distance/speed updates
               static uint32_t last_distance_update = 0;
               uint32_t now = millis();

--- a/common/sen0609-common.yaml
+++ b/common/sen0609-common.yaml
@@ -28,7 +28,7 @@ uart:
             }
             
             // Parse presence detection data: $DFHPD,1,,,*
-            if (data.find("$DFHPD") == 0) {
+            if (data.find("$$DFHPD") == 0) {
               size_t comma1 = data.find(',', 6);
               if (comma1 != std::string::npos) {
                 std::string presence_str = data.substr(comma1 + 1, 1);
@@ -92,7 +92,7 @@ uart:
             }
             
             // Parse distance and speed data: $DFDMD,target_count,target_number,distance,speed,energy,,*
-            if (data.find("$DFDMD") == 0) {
+            if (data.find("$$DFDMD") == 0) {
               // Throttling for distance/speed updates
               static uint32_t last_distance_update = 0;
               uint32_t now = millis();


### PR DESCRIPTION
ESPHOME treats `$D` as a variable, which throws a build warning when it doesn't match. $$ converts to $, but doesn't throw an error.