### PR TITLE
Escape $ in DFHPD/DFDMD protocol markers to fix substitution warning

### DIFF
--- a/common/sen0609-common.yaml
+++ b/common/sen0609-common.yaml
@@ -27,8 +27,8 @@ uart:
               data += char(bytes[i]);
             }
             
-            // Parse presence detection data: $DFHPD,1,,,*
-            if (data.find("$DFHPD") == 0) {
+            // Parse presence detection data: $$DFHPD,1,,,*
+            if (data.find("$$DFHPD") == 0) {
               size_t comma1 = data.find(',', 6);
               if (comma1 != std::string::npos) {
                 std::string presence_str = data.substr(comma1 + 1, 1);
@@ -91,8 +91,8 @@ uart:
               last_query_command = "";
             }
             
-            // Parse distance and speed data: $DFDMD,target_count,target_number,distance,speed,energy,,*
-            if (data.find("$DFDMD") == 0) {
+            // Parse distance and speed data: $$DFDMD,target_count,target_number,distance,speed,energy,,*
+            if (data.find("$$DFDMD") == 0) {
               // Throttling for distance/speed updates
               static uint32_t last_distance_update = 0;
               uint32_t now = millis();

--- a/everything-presence-one-st-sen0609-rev1.6.yaml
+++ b/everything-presence-one-st-sen0609-rev1.6.yaml
@@ -211,8 +211,8 @@ uart:
               data += char(bytes[i]);
             }
 
-            // Parse presence detection data: $DFHPD,1,,,*
-            if (data.find("$DFHPD") == 0) {
+            // Parse presence detection data: $$DFHPD,1,,,*
+            if (data.find("$$DFHPD") == 0) {
               size_t comma1 = data.find(',', 6);
               if (comma1 != std::string::npos) {
                 std::string presence_str = data.substr(comma1 + 1, 1);
@@ -275,8 +275,8 @@ uart:
               last_query_command = "";
             }
 
-            // Parse distance and speed data: $DFDMD,target_count,target_number,distance,speed,energy,,*
-            if (data.find("$DFDMD") == 0) {
+            // Parse distance and speed data: $$DFDMD,target_count,target_number,distance,speed,energy,,*
+            if (data.find("$$DFDMD") == 0) {
               // Throttling for distance/speed updates
               static uint32_t last_distance_update = 0;
               uint32_t now = millis();

--- a/everything-presence-one-st-sen0609.yaml
+++ b/everything-presence-one-st-sen0609.yaml
@@ -211,8 +211,8 @@ uart:
               data += char(bytes[i]);
             }
 
-            // Parse presence detection data: $DFHPD,1,,,*
-            if (data.find("$DFHPD") == 0) {
+            // Parse presence detection data: $$DFHPD,1,,,*
+            if (data.find("$$DFHPD") == 0) {
               size_t comma1 = data.find(',', 6);
               if (comma1 != std::string::npos) {
                 std::string presence_str = data.substr(comma1 + 1, 1);
@@ -275,8 +275,8 @@ uart:
               last_query_command = "";
             }
 
-            // Parse distance and speed data: $DFDMD,target_count,target_number,distance,speed,energy,,*
-            if (data.find("$DFDMD") == 0) {
+            // Parse distance and speed data: $$DFDMD,target_count,target_number,distance,speed,energy,,*
+            if (data.find("$$DFDMD") == 0) {
               // Throttling for distance/speed updates
               static uint32_t last_distance_update = 0;
               uint32_t now = millis();


### PR DESCRIPTION
## Summary
- The UART debug lambda checks for the SEN0609's NMEA-style sentence prefixes `$DFHPD` and `$DFDMD` as plain C++ string literals.
- ESPHome's substitution engine scans the raw file text (including lambda bodies) for `$`-prefixed tokens and treats these as undeclared substitution variables, emitting a warning like:
  ```
  WARNING The string '...' looks like an expression, but could not resolve all the variables: 'DFHPD' is undefined
  ```
  which per the warning text is slated to become a hard compile error in a future ESPHome release.
- Per ESPHome's substitution escaping rules, a literal `$` is written as `$$`. Escaping it here silences the false positive with no runtime behavior change — the doubled `$` collapses back to a single `$` before the lambda is compiled, so `data.find("$$DFHPD")` still compiles to `data.find("$DFHPD")`.
- The same lambda is duplicated in three places (`common/sen0609-common.yaml`, `everything-presence-one-st-sen0609.yaml`, `everything-presence-one-st-sen0609-rev1.6.yaml`), so all three needed the same fix.

Fixes #306